### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add the `releaseBranch:` block to `enonic-gradle.yml` so the release-tools workflow recognizes both `master` and `2.x` as release branches. This mirrors the maintenance-branch pattern used in `enonic/app-booster`.

This is the maintenance branch for the XP 7 line. `master` will move to XP 8 in a separate PR; this branch keeps `xpVersion=7.0.0` and `version=2.0.2-SNAPSHOT` unchanged.