### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,13 +13,13 @@ repositories {
 
 dependencies {
     implementation xplibs.api.script
-    compileOnly "org.bouncycastle:bcprov-jdk15on:1.70"
-    implementation "org.apache.httpcomponents:httpasyncclient:4.1.5"
-    implementation "org.bitbucket.b_c:jose4j:0.9.6"
-    implementation "nl.martijndwars:web-push:5.1.2"
+    compileOnly libs.bcprov.jdk15on
+    implementation libs.httpasyncclient
+    implementation libs.jose4j
+    implementation libs.web.push
 
     testImplementation "com.enonic.xp:testing:${xpVersion}"
-    testImplementation "org.bouncycastle:bcprov-jdk15on:1.70"
+    testImplementation libs.bcprov.jdk15on
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,11 @@
+[versions]
+bcprov-jdk15on  = "1.70"
+httpasyncclient = "4.1.5"
+jose4j          = "0.9.6"
+web-push        = "5.1.2"
+
+[libraries]
+bcprov-jdk15on  = { module = "org.bouncycastle:bcprov-jdk15on",           version.ref = "bcprov-jdk15on" }
+httpasyncclient = { module = "org.apache.httpcomponents:httpasyncclient", version.ref = "httpasyncclient" }
+jose4j          = { module = "org.bitbucket.b_c:jose4j",                  version.ref = "jose4j" }
+web-push        = { module = "nl.martijndwars:web-push",                  version.ref = "web-push" }


### PR DESCRIPTION
Move the four inline-versioned dependencies in `build.gradle` to a new
`gradle/libs.versions.toml` catalog. Pin-for-pin migration — no version
bumps; the resolved `runtimeClasspath` is byte-identical pre/post.

## Conventions adopted

- `[versions]` and `[libraries]` sorted alphabetically.
- Short, lowercase, hyphen-separated keys matching artifact names
  (consistent with `app-features`, `app-adfs-idprovider`, etc.).
- `version.ref` preferred over inline `version = "x.y"` so the version
  line stands alone.
- `xpVersion` left in `gradle.properties` (the rest of the toolchain
  expects it there).
- `xplibs.*` accessors and the version-less junit `testRuntimeOnly`
  deps left untouched.

## New catalog

```toml
[versions]
bcprov-jdk15on  = "1.70"
httpasyncclient = "4.1.5"
jose4j          = "0.9.6"
web-push        = "5.1.2"

[libraries]
bcprov-jdk15on  = { module = "org.bouncycastle:bcprov-jdk15on",           version.ref = "bcprov-jdk15on" }
httpasyncclient = { module = "org.apache.httpcomponents:httpasyncclient", version.ref = "httpasyncclient" }
jose4j          = { module = "org.bitbucket.b_c:jose4j",                  version.ref = "jose4j" }
web-push        = { module = "nl.martijndwars:web-push",                  version.ref = "web-push" }
```

## Verification

- `./gradlew build --refresh-dependencies` green.
- `./gradlew dependencies --configuration runtimeClasspath` output
  identical between pre- and post-migration HEAD.

<sub>*Drafted with AI assistance*</sub>