### PR TITLE
Add @enonic-types/lib-notifications types package #65

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             master
             2.x

--- a/build.gradle
+++ b/build.gradle
@@ -36,3 +36,15 @@ jacocoTestReport {
 }
 
 check.dependsOn jacocoTestReport
+
+// Assemble the @enonic-types/lib-notifications npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,71 @@
+import type { ByteSource } from "@enonic-types/core";
+
+declare module "/lib/notifications" {
+    /**
+     * A VAPID public/private key pair, in both Base64-URL (unpadded) and
+     * binary-stream representations.
+     */
+    export interface KeyPair {
+        /** Private key encoded as Base64-URL (unpadded). Must never be sent to the client. */
+        privateKey: string;
+        /** Public key encoded as Base64-URL (unpadded). */
+        publicKey: string;
+        /** Private key as a binary stream. */
+        privateKeyBytes: ByteSource;
+        /** Public key as a binary stream. */
+        publicKeyBytes: ByteSource;
+    }
+
+    /**
+     * Parameters shared by `send` and `sendAsync`.
+     */
+    export interface NotificationParams {
+        /** VAPID public key (Base64-URL). */
+        publicKey: string;
+        /** VAPID private key (Base64-URL). */
+        privateKey: string;
+        /** The Push service endpoint URL, received as part of the Subscription data. */
+        endpoint: string;
+        /** The auth key received as part of the Subscription data. */
+        auth: string;
+        /** The p256dh key received as part of the Subscription data. */
+        receiverKey: string;
+        /** Message payload. Objects are JSON-stringified before being sent. */
+        payload?: string | Record<string, unknown>;
+    }
+
+    /**
+     * Parameters for `sendAsync`. Adds optional callbacks reporting the outcome.
+     */
+    export interface AsyncNotificationParams extends NotificationParams {
+        /** Called with the HTTP status code when the push succeeds (2xx). */
+        success?: (status: number) => void;
+        /** Called with the HTTP status code on failure, or `0` if an exception was thrown. */
+        error?: (status: number) => void;
+    }
+
+    /**
+     * Generate a VAPID public/private key pair.
+     *
+     * @returns A new key pair with Base64-URL-encoded strings and their binary streams.
+     */
+    export function generateKeyPair(): KeyPair;
+
+    /**
+     * Send a push notification to a client synchronously.
+     *
+     * @param notification Push parameters.
+     * @returns The HTTP status code from the push service response (2xx on success).
+     */
+    export function send(notification: NotificationParams): number;
+
+    /**
+     * Send a push notification to a client asynchronously.
+     * Returns immediately; the result is reported via the optional `success` / `error` callbacks.
+     *
+     * @param notification Push parameters, plus optional `success` / `error` callbacks.
+     */
+    export function sendAsync(notification: AsyncNotificationParams): void;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@enonic-types/lib-notifications",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP Notifications library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-notifications",
+    "notifications",
+    "webpush",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-notifications#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-notifications.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-notifications/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}


### PR DESCRIPTION
Publishes a TypeScript types package for lib-notifications so consumers get typed access to `/lib/notifications` out of the box instead of hand-declaring the module locally.

## Changes
- `types/index.d.ts` — ambient `declare module "/lib/notifications"` with all three exports (`generateKeyPair`, `send`, `sendAsync`) plus `KeyPair`, `NotificationParams`, `AsyncNotificationParams`. Signatures verified against `src/main/resources/lib/notifications.js` and the underlying `KeyPairGenerationBean` / `KeyPairMapper` / `PushBean` Java code (return types, callback signatures, optional-vs-required fields).
- `types/package.json` — `@enonic-types/lib-notifications` manifest (version substituted at build time from `project.version`).
- `build.gradle` — `assembleTypes` Copy task builds `build/types` with the current `project.version` injected; `jar.dependsOn assembleTypes` (mirrors the lib-mustache pattern).
- `.github/workflows/enonic-gradle.yml` — `npmPublish: true` on build-and-publish + top-level `id-token: write` / `contents: write` for OIDC trusted publishing.

Reference implementation: enonic/lib-mustache#66 (merged).

Verified locally: `./gradlew build` green; `build/types/` contains `index.d.ts` + `package.json` with `version: "3.1.0-SNAPSHOT"` substituted.

**Note:** the first publish of a brand-new `@enonic-types/lib-notifications` needs the npm trusted-publisher / package access configured org-side. Depends on enonic/release-tools#71 (merged).

Closes #65

Generated with [Claude Code](https://claude.com/claude-code)