### PR TITLE
Align docs to standard layout #67

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,6 +1,8 @@
 = Push Notifications Library
 
-image::https://img.shields.io/badge/xp-7.+-blue.svg[role="right"]
+image::https://img.shields.io/badge/xp-8.+-blue.svg[role="right"]
+
+NOTE: Versions 3.x target XP 8+.
 
 This library allows sending Push Notifications to a web application.
 
@@ -9,7 +11,7 @@ To start using this library, add the following into your `build.gradle` file:
 [source,groovy]
 ----
 dependencies {
-  include 'com.enonic.lib:lib-notifications:2.0.0'
+  include 'com.enonic.lib:lib-notifications:3.0.0'
 }
 ----
 
@@ -218,4 +220,4 @@ notifications.sendAsync({
 
 == Compatibility
 
-This library requires Enonic XP release *7.0.0* or higher.
+This library requires Enonic XP release *8.0.0* or higher.

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -2,12 +2,12 @@
   "versions": [
     {
       "label": "stable",
-      "checkout": "2.x",
+      "checkout": "3.x",
       "latest": true
     },
     {
-      "label": "next",
-      "checkout": "master"
+      "label": "2.x",
+      "checkout": "2.x"
     }
   ]
 }


### PR DESCRIPTION
Aligns the `master` docs with the reference `enonic/lib-cors` layout and refreshes the stale XP-7 references (master is `3.1.0-SNAPSHOT` targeting `xpVersion=8.0.2`).

## Changes

- `docs/index.adoc`
  - Bump the XP badge to `xp-8.+`.
  - Add `NOTE: Versions 3.x target XP 8+.` near the top (matches the reference layout).
  - Update the dependency example from `lib-notifications:2.0.0` to `3.0.0`.
  - Update the Compatibility statement to require XP 8+.
- `docs/versions.json`
  - Drop the `next` entry (reference layout doesn't include one).
  - List `stable` (checkout `3.x`, `"latest": true`) first, followed by `2.x`.
- `.github/workflows/enonic-docgen.yml`: no change — already triggers on `master`, `2.x`, `3.x` (via commit fd4f28c).

## Version-history clutter cleanup

I re-read `docs/**` looking for the noise the issue lists (`added in vX.Y`, `since X.Y`, `Starting from version X …`, pre-XP-8 legacy notes). I did not find any inline "added when" annotations in the current docs — the only version-specific bits were the XP-7 badge, the pinned dependency version, and the Compatibility line, all of which are stale rather than history-annotations, and all handled above.

The two "previously" mentions in "Sending push notifications" (`previously subscribed`, `Previously generated with generateKeyPair`) describe the operational flow, not version history, so they stay.

## Follow-up

Once this lands on `master`, a follow-up PR will cherry-pick the clutter/NOTE/versions.json changes to the `3.x` stable branch. The `2.x` branch stays untouched.

Closes #67