### PR TITLE
Align docs to standard layout #67

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -2,6 +2,8 @@
 
 image::https://img.shields.io/badge/xp-8.+-blue.svg[role="right"]
 
+NOTE: Versions 3.x target XP 8+.
+
 This library allows sending Push Notifications to a web application.
 
 To start using this library, add the following into your `build.gradle` file:

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,13 +1,13 @@
 {
   "versions": [
     {
-      "label": "2.x",
-      "checkout": "2.x"
-    },
-    {
       "label": "stable",
       "checkout": "3.x",
       "latest": true
+    },
+    {
+      "label": "2.x",
+      "checkout": "2.x"
     }
   ]
 }


### PR DESCRIPTION
Companion PR to enonic/lib-notifications#68. Brings the `3.x` stable branch docs in line with the reference `enonic/lib-cors` layout.

## Changes

- `docs/index.adoc`: add `NOTE: Versions 3.x target XP 8+.` near the top (matches the reference layout).
- `docs/versions.json`: reorder so `stable` (checkout `3.x`, `"latest": true`) comes first, followed by `2.x` — matches the reference format.
- `.github/workflows/enonic-docgen.yml`: no change — already triggers on `master`, `2.x`, `3.x`.

## Version-history clutter

I re-verified `docs/**` on `3.x` for `added in vX.Y` / `since X.Y` / `Starting from version X` / pre-XP-8 legacy notes. None found — the `3.x` docs are already clean of that kind of noise. The XP-8 badge, dependency example (`3.0.0`) and Compatibility line here are already up-to-date.

## Scope

- `2.x` branch is intentionally left untouched (it remains the XP 7 documentation).
- This PR is scoped strictly to docs — no source, tests, or build config touched.

Closes #67