### PR TITLE
Web push to FCM fails with 403 #70

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -71,6 +71,7 @@ Sending push notifications from the server to a client (that has previously subs
 - `*auth*` Obtained on the client, in the https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription[Subscription] object.
 - `*receiverKey*` Obtained on the client, in the https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription[Subscription] object.
 - `*payload*` Optional object or string to be pushed to the client.
+- `*subject*` Optional VAPID `sub` contact (a `mailto:` or `https:` URI).
 
 [source,js]
 ----
@@ -113,7 +114,7 @@ Send a push notification to a client.
 *Parameters*
 
 The request function takes a parameter object with options. +
-All the parameters are mandatory except `payload`.
+All the parameters are mandatory except `payload` and `subject`.
 
 * `options` (_object_) Parameters to send the push notification.
 ** `*publicKey*` (_string_) VAPID public key (encoded as Base64).
@@ -122,6 +123,7 @@ All the parameters are mandatory except `payload`.
 ** `*auth*` (_string_) The auth key received as part of the Subscription data.
 ** `*receiverKey*` (_string_) The *p256dh* key received as part of the Subscription data.
 ** `*payload*` (_string_|_object_) Message payload to send. Either a string or an object that will be serialized as JSON.
+** `*subject*` (_string_) _Optional._ VAPID `sub` claim — a `mailto:` or `https:` contact URI identifying the sender to the push service.
 
 *Returns*
 
@@ -139,7 +141,7 @@ The result of the notification can be obtained by passing a callback function in
 *Parameters*
 
 The request function takes a parameter object with options. +
-All the parameters are mandatory except `payload`, `success` and `error`.
+All the parameters are mandatory except `payload`, `subject`, `success` and `error`.
 
 * `options` (_object_) Parameters to send the push notification.
 ** `*publicKey*` (_string_) VAPID public key (encoded as Base64).
@@ -148,6 +150,7 @@ All the parameters are mandatory except `payload`, `success` and `error`.
 ** `*auth*` (_string_) The auth key received as part of the Subscription data.
 ** `*receiverKey*` (_string_) The *p256dh* key received as part of the Subscription data.
 ** `*payload*` (_string_|_object_) Message payload to send. Either a string or an object that will be serialized as JSON.
+** `*subject*` (_string_) _Optional._ VAPID `sub` claim — a `mailto:` or `https:` contact URI identifying the sender to the push service.
 ** `*success*` (_function_) A function to be called if the sending succeeds. The function gets passed the status from the HTTP request made.
 ** `*error*` (_function_) A function to be called if the sending fails.
 

--- a/src/main/java/com/enonic/lib/notifications/PushBean.java
+++ b/src/main/java/com/enonic/lib/notifications/PushBean.java
@@ -4,19 +4,24 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.Security;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jose4j.lang.JoseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import nl.martijndwars.webpush.Encoding;
 import nl.martijndwars.webpush.Notification;
 import nl.martijndwars.webpush.PushService;
 import nl.martijndwars.webpush.Utils;
 
 public final class PushBean
 {
+    private static final Logger LOG = LoggerFactory.getLogger( PushBean.class );
+
     static
     {
         if ( Security.getProvider( BouncyCastleProvider.PROVIDER_NAME ) == null )
@@ -37,6 +42,8 @@ public final class PushBean
 
     private String payload;
 
+    private String subject;
+
     private Consumer<Integer> success;
 
     private Consumer<Integer> error;
@@ -49,7 +56,7 @@ public final class PushBean
 
     public void sendAsync()
     {
-        Executors.newSingleThreadExecutor().submit( this::doSendAsync );
+        Thread.startVirtualThread( this::doSendAsync );
     }
 
     private int doSend()
@@ -61,8 +68,30 @@ public final class PushBean
         pushService.setPublicKey( Utils.loadPublicKey( publicKey ) );
         pushService.setPrivateKey( Utils.loadPrivateKey( privateKey ) );
 
-        final HttpResponse httpResponse = pushService.send( notification );
-        return httpResponse.getStatusLine().getStatusCode();
+        if ( subject != null && !subject.isBlank() )
+        {
+            pushService.setSubject( subject );
+        }
+
+        final HttpResponse httpResponse = pushService.send( notification, Encoding.AES128GCM );
+        final int status = httpResponse.getStatusLine().getStatusCode();
+        if ( ( status < 200 || status >= 300 ) && LOG.isDebugEnabled() )
+        {
+            LOG.debug( "Web push rejected: status={} endpoint={} body={}", status, endpoint, readBody( httpResponse ) );
+        }
+        return status;
+    }
+
+    private static String readBody( final HttpResponse httpResponse )
+    {
+        try
+        {
+            return httpResponse.getEntity() != null ? EntityUtils.toString( httpResponse.getEntity() ) : "";
+        }
+        catch ( final IOException e )
+        {
+            return "<unreadable: " + e.getMessage() + ">";
+        }
     }
 
     private void doSendAsync()
@@ -111,6 +140,11 @@ public final class PushBean
     public void setPayload( final String payload )
     {
         this.payload = payload;
+    }
+
+    public void setSubject( final String subject )
+    {
+        this.subject = subject;
     }
 
     public void setReceiverKey( final String receiverKey )

--- a/src/main/resources/lib/notifications.js
+++ b/src/main/resources/lib/notifications.js
@@ -28,6 +28,7 @@ exports.generateKeyPair = function () {
  * @param {string} notification.auth The auth key received as part of the Subscription data.
  * @param {string} notification.receiverKey The p256dh key received as part of the Subscription data.
  * @param {string|object} [notification.payload] Message payload to send.
+ * @param {string} [notification.subject] Optional VAPID "sub" claim — a mailto: or https: contact URI.
  * @returns {status} Response status from the HTTP request made. 2xx if the notification is successfully sent (e.g. 201 CREATED).
  */
 exports.send = function (notification) {
@@ -49,6 +50,7 @@ exports.send = function (notification) {
     pushBean.auth = notification.auth;
     pushBean.receiverKey = notification.receiverKey;
     pushBean.payload = payload;
+    pushBean.subject = __.nullOrValue(notification.subject);
 
     return __.toNativeObject(pushBean.send());
 };
@@ -64,6 +66,7 @@ exports.send = function (notification) {
  * @param {string} notification.auth The auth key received as part of the Subscription data.
  * @param {string} notification.receiverKey The p256dh key received as part of the Subscription data.
  * @param {string|object} [notification.payload] Message payload to send.
+ * @param {string} [notification.subject] Optional VAPID "sub" claim — a mailto: or https: contact URI.
  * @param {function} notification.success A function to be called if the sending succeeds. The function gets passed the status from the HTTP request made.
  * @param {function} notification.error A function to be called if the sending fails.
  */
@@ -86,6 +89,7 @@ exports.sendAsync = function (notification) {
     pushBean.auth = notification.auth;
     pushBean.receiverKey = notification.receiverKey;
     pushBean.payload = payload;
+    pushBean.subject = __.nullOrValue(notification.subject);
     pushBean.success = __.nullOrValue(notification.success);
     pushBean.error = __.nullOrValue(notification.error);
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,6 +32,8 @@ declare module "/lib/notifications" {
         receiverKey: string;
         /** Message payload. Objects are JSON-stringified before being sent. */
         payload?: string | Record<string, unknown>;
+        /** Optional VAPID "sub" claim — a `mailto:` or `https:` contact URI identifying the sender to the push service. */
+        subject?: string;
     }
 
     /**


### PR DESCRIPTION
Fixes web push delivery to FCM, which rejected the legacy `aesgcm` `Crypto-Key` header with `403`.

- **Encoding (the actual fix):** send with `Encoding.AES128GCM` (RFC 8291) instead of the default `aesgcm`. The salt and keys travel inline in the request body and VAPID goes in the `Authorization` header, so there is no `Crypto-Key` header for FCM to reject.
- **Subject:** add an optional `subject` parameter (the VAPID `sub` claim) to `send`/`sendAsync`, set on the `PushService` when provided.
- **Diagnostics:** when a send fails, log the push-service response body at debug level (guarded by `isDebugEnabled`) — the body carries the actual reason, which was previously discarded.
- **Async:** run `sendAsync` on a virtual thread instead of creating (and never shutting down) a single-thread executor per call. The blocking HTTP send is a good fit for a virtual thread.
- Documented the `subject` parameter in `docs/index.adoc`.

Verified end-to-end against a live FCM (Chrome) subscription: `403` → `201`.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
